### PR TITLE
Replace hardcoded CarierCode from createShippingMethod()

### DIFF
--- a/app/code/Magento/OfflineShipping/Model/Carrier/Tablerate.php
+++ b/app/code/Magento/OfflineShipping/Model/Carrier/Tablerate.php
@@ -278,7 +278,7 @@ class Tablerate extends \Magento\Shipping\Model\Carrier\AbstractCarrier implemen
         /** @var  \Magento\Quote\Model\Quote\Address\RateResult\Method $method */
         $method = $this->_resultMethodFactory->create();
 
-        $method->setCarrier('tablerate');
+        $method->setCarrier($this->getCarrierCode());
         $method->setCarrierTitle($this->getConfigData('title'));
 
         $method->setMethod('bestway');


### PR DESCRIPTION
By taking carrier_code from $this->getCarrierCode(), which fetches $_code from this class, we make it easier to extend the default TableRate class.

With this change, creating a new TableRate carrier is as easy as:
Creating a new TableRate class such as
```
class ExpressTablerate extends \Magento\OfflineShipping\Model\Carrier\Tablerate
{
    /**
     * @var string
     */
    protected $_code = 'express'; // phpcs:ignore
}
```

And creating the a new <config><default><carriers> node in config.xml:
```
            <express>
                <active>0</active>
                <sallowspecific>0</sallowspecific>
                <condition_name>package_weight</condition_name>
                <include_virtual_price>1</include_virtual_price>
                <model>[NameSpace]\Shipping\Model\Carrier\ExpressTablerate</model>
                <name>Table Rate</name>
                <title>Best Way</title>
                <specificerrmsg>This shipping method is not available. To use this shipping method, please contact us.</specificerrmsg>
                <handling_type>F</handling_type>
            </express>
```